### PR TITLE
Jube port allocator should reuse adr so the processes can grab the port ...

### DIFF
--- a/process-manager/src/main/java/io/fabric8/jube/process/service/ProcessManagerService.java
+++ b/process-manager/src/main/java/io/fabric8/jube/process/service/ProcessManagerService.java
@@ -263,6 +263,7 @@ public class ProcessManagerService implements ProcessManagerServiceMBean {
             String hostName = getLocalHostName();
             int idGeneratorPort = 0;
             ss = new ServerSocket(idGeneratorPort);
+            ss.setReuseAddress(true);
             return ss.getLocalPort();
         } catch (Exception e) {
             LOGGER.warn("Failed to allocate port " + key + ". " + e, e);


### PR DESCRIPTION
...without getting port in use errors
